### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3
+ENV PYTHONUNBUFFERED 1
+RUN mkdir /code
+WORKDIR /code
+ADD requirements.txt /code/
+RUN pip install -r requirements.txt
+ADD TEST_RUN.py /code/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # webscrap_sentimentAnal
 takes Finviz articles and gives sentiment score
+
+## Docker setup
+To run the project using docker first install docker.
+Instructions can be found at the bottom of [this page](https://docs.docker.com/install/).
+
+The project can be run either using docker, or using docker-compose.
+Docker-compose adds sugar on top of docker and allows for easily spinning up and down multiple containers.
+
+### Docker compose approach
+To run the container using docker compose,
+```
+docker-compose build && docker-compose up -d
+```
+To stop the container using docker compose
+```
+docker-compose down
+```
+### Pure docker approach
+ build the container run the command,
+```
+docker build -t webscrape .
+```
+Before running the docker container, first stop and delete the previous image.
+Use --mount to be have files generated in the container be transferred into the local directory.
+```
+#stop container if exists
+docker stop devtest
+docker rm devtest
+#rebuild container
+docker build -t webscrape .
+#run container
+docker run -d \
+--name devtest \
+--mount type=bind,source="${pwd}",target=/code \
+webscrape
+
+```
+For some reason the docker container only build isn't working properly mounting the local directory as a volume. That's fine since this is just an example of how to build using purely docker.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  bot:
+    build: .
+    command: python3 TEST_RUN.py
+    volumes: # makes articles.csv be written to local directory
+      - .:/code
+#TODO: have code write to an output directory to seperate concerns

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+bs4
+requests

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,2 @@
+REM this should work on windows
+docker-compose build && docker-compose up -d

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,2 @@
+#this should work on linux
+docker-compose build && docker-compose up -d


### PR DESCRIPTION
Adds a Dockerfile to specify how to build the python application and a docker-compose.yml file to specify how to launch the services and what volumes to mount.
Additionally I added run.sh and run.bat. I tested run.sh on linux but I don't have access to a windows environment to test the run.bat.

Instructions for getting set up are included in the README.md.